### PR TITLE
More fixes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,0 @@
-clang++ -Wall main.cpp chip8.cpp frontend.cpp -o chip8emu -lSDL2 -lSDL2_ttf
-

--- a/test.sh
+++ b/test.sh
@@ -1,2 +1,0 @@
-bash build.sh
-./chip8emu


### PR DESCRIPTION
- Fix subtraction borrow computation (counterintuitively should be 0 when borrowing and 1 when not)
- Fix bit shifts (should shift Y and copy it to X instead of shifting X directly)
- Fix draw instruction (should not wrap pixels around, only the entire sprite)
- Fix a potential segfault if a corrupted ROM is bigger than memory size

- Remove shell build scripts in favor of make
- Clean some instructions that can be written more concisely